### PR TITLE
Prevent README release-line drift

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,10 +16,10 @@ This release ships Meta-Architect as a Codex-native skills system with:
 
 Target package state:
 - npm package: `@jstn-sdk/ma@0.1.13`
-- npm registry state: pending publish
-- publishability note: `0.1.12` is already published, so `0.1.13` is the next publishable package line
+- npm registry state: published as `latest`
+- publishability note: `0.1.13` is published; future patch work must advance the version before another npm publish
 - release tag: `v0.1.13`
-- GitHub release: pending publish for `v0.1.13`
+- GitHub release: https://github.com/JustineDevs/meta-architect/releases/tag/v0.1.13
 
 ## Verification
 
@@ -46,5 +46,5 @@ This release is only considered real if:
 
 Current release-readiness state:
 - `docs/qa/release-issue-gates-0.1.13.json` records all tracked `v0.1.13` issues as `passed` with implementation, verification, production proof, and labels
-- local release gates are expected to remain green immediately before PR and publish
-- npm publication has not been run yet for `@jstn-sdk/ma@0.1.13`
+- local release gates passed before publish and must remain green for any follow-up PR
+- npm publication completed for `@jstn-sdk/ma@0.1.13`

--- a/scripts/release-sync.js
+++ b/scripts/release-sync.js
@@ -184,6 +184,27 @@ function updateCurrentSurfaceFile(file, oldVersion, nextVersion) {
   writeText(file, content);
 }
 
+function syncReadmeReleaseBanner(nextVersion) {
+  const readmePath = "README.md";
+  const nextTag = `v${nextVersion}`;
+  let content = readText(readmePath);
+
+  content = content.replace(
+    /> Meta-Architect `v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?` is a production-grade skills line\./,
+    `> Meta-Architect \`${nextTag}\` is a production-grade skills line.`,
+  );
+  content = content.replace(
+    /> From `v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?` onward, the package is expected to ship with stable skill contracts, deterministic packaging, explicit release gates, and honest install and publish surfaces\./,
+    `> From \`${nextTag}\` onward, the package is expected to ship with stable skill contracts, deterministic packaging, explicit release gates, and honest install and publish surfaces.`,
+  );
+  content = content.replace(
+    /<td><strong>Release line<\/strong><\/td>\s*\n\s*<td><code>v[0-9]+\.[0-9]+\.[0-9]+(?:-[^<]+)?<\/code><\/td>/,
+    `<td><strong>Release line</strong></td>\n    <td><code>${nextTag}</code></td>`,
+  );
+
+  writeText(readmePath, content);
+}
+
 function syncPackageVersion(nextVersion) {
   const pkg = readJson("package.json");
   const lock = readJson("package-lock.json");
@@ -348,6 +369,7 @@ function main() {
   syncPluginVersions(nextVersion);
   prependChangelog(nextVersion);
   syncCurrentReleaseFiles(currentVersion, nextVersion);
+  syncReadmeReleaseBanner(nextVersion);
   syncSupportingCode(currentVersion, nextVersion);
   rewriteReleaseState(nextVersion, currentVersion);
 

--- a/scripts/release-verify.js
+++ b/scripts/release-verify.js
@@ -131,6 +131,43 @@ function verifyCoverageDoc({ version, gitTag }) {
   assert(!content.includes("v0.1.0 release bar"), "COVERAGE.md: stale release bar");
 }
 
+function verifyReadmeReleaseBanner({ gitTag }) {
+  const content = readText("README.md");
+  assert(
+    content.includes("> [!IMPORTANT]"),
+    "README.md: missing release-line important admonition",
+  );
+  assert(
+    content.includes(`> Meta-Architect \`${gitTag}\` is a production-grade skills line.`),
+    "README.md: stale production-grade skills line version",
+  );
+  assert(
+    content.includes(
+      `> From \`${gitTag}\` onward, the package is expected to ship with stable skill contracts, deterministic packaging, explicit release gates, and honest install and publish surfaces.`,
+    ),
+    "README.md: stale release expectation version",
+  );
+  assert(
+    content.includes(`<td><code>${gitTag}</code></td>`),
+    "README.md: stale release line table version",
+  );
+
+  const bannerVersions = [
+    ...content.matchAll(
+      /(?:Meta-Architect `(v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?)` is a production-grade skills line|From `(v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?)` onward)/g,
+    ),
+  ]
+    .map((match) => match[1] ?? match[2])
+    .filter(Boolean);
+  assert(bannerVersions.length >= 2, "README.md: release banner versions not found");
+  for (const bannerVersion of bannerVersions) {
+    assert(
+      bannerVersion === gitTag,
+      `README.md: release banner version drift: expected ${gitTag}, got ${bannerVersion}`,
+    );
+  }
+}
+
 function verifyCanonicalSemanticSurfaces({ version, gitTag }) {
   const usageWorkflow = readText(path.join("example", "usage-workflow.md"));
   assert(
@@ -178,7 +215,7 @@ function verifyCanonicalSemanticSurfaces({ version, gitTag }) {
 
   const currentQa = readText(path.join("docs", "qa", `release-readiness-${version}.md`));
   assert(
-    currentQa.includes("Harden Meta-Architect v0.1.13 semantic core"),
+    currentQa.includes(`Harden Meta-Architect ${gitTag} semantic core`),
     `docs/qa/release-readiness-${version}.md: missing realistic semantic smoke idea`,
   );
   assert(
@@ -219,6 +256,7 @@ function main() {
   verifyNpmIgnore();
   verifyDemoDoc({ version, gitTag });
   verifyCoverageDoc({ version, gitTag });
+  verifyReadmeReleaseBanner({ gitTag });
   verifyCanonicalSemanticSurfaces({ version, gitTag });
 
   const changelog = readText("CHANGELOG.md");

--- a/test/release-sync.test.js
+++ b/test/release-sync.test.js
@@ -16,6 +16,7 @@ test("release-sync bumps patch and rewrites the active release surfaces", async 
   const tempRoot = await createTempRepo("meta-architect-release-sync-", repoRoot);
   const pkgBefore = JSON.parse(await fs.readFile(path.join(tempRoot, "package.json"), "utf8"));
   const nextVersion = bumpPatch(pkgBefore.version);
+  const readmePath = path.join(tempRoot, "README.md");
   const currentQaPath = path.join(
     tempRoot,
     "docs",
@@ -23,6 +24,20 @@ test("release-sync bumps patch and rewrites the active release surfaces", async 
     `release-readiness-${pkgBefore.version}.md`,
   );
   const nextQaPath = path.join(tempRoot, "docs", "qa", `release-readiness-${nextVersion}.md`);
+  const staleReadme = (await fs.readFile(readmePath, "utf8"))
+    .replace(
+      /> Meta-Architect `v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?` is a production-grade skills line\./,
+      "> Meta-Architect `v0.1.12` is a production-grade skills line.",
+    )
+    .replace(
+      /> From `v[0-9]+\.[0-9]+\.[0-9]+(?:-[^`]+)?` onward, the package is expected to ship with stable skill contracts, deterministic packaging, explicit release gates, and honest install and publish surfaces\./,
+      "> From `v0.1.12` onward, the package is expected to ship with stable skill contracts, deterministic packaging, explicit release gates, and honest install and publish surfaces.",
+    )
+    .replace(
+      /<td><strong>Release line<\/strong><\/td>\s*\n\s*<td><code>v[0-9]+\.[0-9]+\.[0-9]+(?:-[^<]+)?<\/code><\/td>/,
+      "<td><strong>Release line</strong></td>\n    <td><code>v0.1.12</code></td>",
+    );
+  await fs.writeFile(readmePath, staleReadme);
 
   const result = spawnPortable(
     process.execPath,
@@ -47,8 +62,16 @@ test("release-sync bumps patch and rewrites the active release surfaces", async 
     "utf8",
   );
   const releaseText = await fs.readFile(path.join(tempRoot, "RELEASE.md"), "utf8");
+  const readmeText = await fs.readFile(readmePath, "utf8");
   assert.match(releaseText, new RegExp(`@jstn-sdk/ma@${nextVersion}`));
   assert.match(releaseText, new RegExp(`v${nextVersion}`));
+  assert.match(
+    readmeText,
+    new RegExp(`Meta-Architect \`v${nextVersion}\` is a production-grade skills line\\.`),
+  );
+  assert.match(readmeText, new RegExp(`From \`v${nextVersion}\` onward`));
+  assert.match(readmeText, new RegExp(`<td><code>v${nextVersion}</code></td>`));
+  assert.doesNotMatch(readmeText, /Meta-Architect `v0\.1\.12`|From `v0\.1\.12` onward/);
   assert.match(
     pluginManifest,
     /"keywords": \["codex", "skills", "architecture", "workflow", "review"\]/,


### PR DESCRIPTION
## Summary
- makes the README production release banner an explicit release-sync surface
- adds release verification that fails when the README banner or release-line table drifts from package.json
- adds a regression test that starts with stale v0.1.12 README text and proves release-sync repairs it

## Verification
- node --test test/release-sync.test.js
- npm run release:verify