### PR TITLE
Promote development to main after real demo kit

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -207,6 +207,7 @@ Expected:
 ## 9. Demo production package proof
 
 ```bash
+npm run demo:smoke
 node scripts/release-verify.js
 npm run check
 npm test
@@ -217,12 +218,20 @@ Expected package proof:
 
 - package name is `@jstn-sdk/ma`
 - version line is `0.1.13`
+- `npm run demo:smoke` creates a realistic Northstar Logistics workspace and Obsidian vault under `/tmp/ma-real-demo-*`
+- the smoke writes `.ma/evidence/real-demo-smoke-proof.json` in that temporary workspace
 - `DEMO.md` is included
 - `COVERAGE.md` is included
 - `data/clone-data.proof.json`, `data/clone-data.ledger.json`, and `data/clone-data.rvf` are included
 - runtime state such as `.ma/`, `.omx/`, `node_modules/`, `test/`, and local caches are excluded
 
 ## 10. Full release demo
+
+For a buyer-facing walkthrough, use the real demo kit:
+
+- [Real Demo Runbook](./docs/demo/REAL_DEMO_RUNBOOK.md)
+- [Demo Story](./docs/demo/DEMO_STORY.md)
+- [Prospect Checklist](./docs/demo/PROSPECT_CHECKLIST.md)
 
 The strongest single command:
 

--- a/README.md
+++ b/README.md
@@ -854,6 +854,9 @@ Release automation:
 | [MCP Setup](./docs/mcp-setup.md) | evidence endpoint policy |
 | [Plugin README](./plugins/meta-architect/README.md) | plugin distribution surface |
 | [Production Demo Guide](./DEMO.md) | real MA release-hardening walkthrough |
+| [Real Demo Runbook](./docs/demo/REAL_DEMO_RUNBOOK.md) | live buyer-facing demo path with smoke fallback |
+| [Demo Story](./docs/demo/DEMO_STORY.md) | narrative script for `$maestro`, Obsidian, learning, and release proof |
+| [Prospect Checklist](./docs/demo/PROSPECT_CHECKLIST.md) | pre-call setup, no-test-branding, and leave-behind checklist |
 | [Coverage Matrix](./COVERAGE.md) | current verified capability and package proof map |
 | [Release Spec](./docs/release-spec.md) | release and gate policy |
 | [Release Readiness](./docs/qa/release-readiness-0.1.13.md) | QA evidence for the `v0.1.13` line |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ Meta-Architect documentation is organized by operator task.
 
 - [Getting Started](./getting-started.md)
 - [Production Demo Guide](../DEMO.md)
+- [Real Demo Runbook](./demo/REAL_DEMO_RUNBOOK.md)
+- [Demo Story](./demo/DEMO_STORY.md)
+- [Prospect Checklist](./demo/PROSPECT_CHECKLIST.md)
 - [Coverage Matrix](../COVERAGE.md)
 - [Release Spec](./release-spec.md)
 - [Skills Reference](./skills.md)

--- a/docs/demo/DEMO_STORY.md
+++ b/docs/demo/DEMO_STORY.md
@@ -1,0 +1,80 @@
+# Demo Story
+
+## Narrative
+
+Northstar Logistics has an existing dispatch analytics workspace. The team wants a production release, but their current process has three recurring failures:
+
+- release gates are discovered too late
+- operational knowledge is trapped in notes
+- autonomous agents ask for permission instead of driving safe next steps
+
+Meta-Architect enters as the operating layer that gives the buyer a controlled path from idea to verified action.
+
+## Opening
+
+Set expectations:
+
+> I am going to give MA one realistic release goal. The important part is not that it prints a plan. The important part is that it routes work through the right roles, keeps Obsidian notes as brain context, protects evidence boundaries, and produces proof we can inspect.
+
+## Act 1: The Idea
+
+Prompt:
+
+```text
+$maestro Northstar Logistics wants to harden an existing dispatch analytics workspace for a production release. Inspect the repo, use Obsidian vault notes as brain context, choose the right MA roles, find risks, and produce the next release-safe action without asking for permission.
+```
+
+Business outcome:
+
+- The buyer sees one entry point instead of deciding which agent or role should act.
+- MA does not behave like a passive chatbot.
+
+## Act 2: The Brain Context
+
+Show Obsidian notes:
+
+- `Northstar/Dispatch Release Objective.md`
+- `Northstar/Risk Register.md`
+- `Meta-Architect/Map of Content.md`
+
+Business outcome:
+
+- Existing team knowledge becomes usable without becoming fake build evidence.
+- Wikilinks make the context navigable and explainable.
+
+## Act 3: The Gates
+
+Show:
+
+- `.ma/decisions.json`
+- `.ma/plans/maestro.md`
+- `.ma/state/maestro-state.json`
+
+Business outcome:
+
+- Architecture, evidence, logic, security, DX, and build readiness remain separate.
+- The buyer can audit why MA did or did not allow execution.
+
+## Act 4: Reliability Over Time
+
+Run:
+
+```bash
+npm run demo:smoke
+```
+
+Business outcome:
+
+- MA proves learning-loop readiness, context economy, environment awareness, Ralph execution handoff, and Obsidian integration through a repeatable smoke.
+
+## Close
+
+End with:
+
+```bash
+npm run release:verify
+```
+
+Business outcome:
+
+- The demo closes on a deterministic production gate, not a subjective impression.

--- a/docs/demo/PROSPECT_CHECKLIST.md
+++ b/docs/demo/PROSPECT_CHECKLIST.md
@@ -1,0 +1,45 @@
+# Prospect Demo Checklist
+
+Use this before a live Meta-Architect demo.
+
+## Preparation
+
+- Map the prospect's top three objectives to MA features before the call.
+- Use prospect-safe names and industry-relevant data.
+- Remove `Demo Account`, `Test Company`, `Sample Co`, and competitor names from visible screens.
+- Enable only relevant modules and docs for the story.
+- Keep [Real Demo Runbook](./REAL_DEMO_RUNBOOK.md) open.
+
+## Technology
+
+- Run `npm run demo:smoke` before the call.
+- Run `npm run release:verify` before the call.
+- Keep a terminal tab ready at the repository root.
+- Keep a backup terminal tab ready with the latest smoke JSON proof path.
+- Disable desktop notifications, email popups, and distracting meeting overlays.
+- Use readable terminal font size and screen resolution.
+
+## Storytelling
+
+- Start with the buyer problem, not the feature list.
+- Make `$maestro` the one-entry workflow.
+- Show Obsidian as semantic brain context, not build evidence.
+- Tie every lane to a business outcome.
+- Pause after each major proof point for questions.
+
+## Proof Points
+
+- Install path: jsDelivr or npm fallback.
+- Runtime setup: `ma setup`, `ma doctor`, `ma status --maestro-view`.
+- Orchestration: `$maestro` chooses safe next lanes.
+- Knowledge: Obsidian notes are graph-linked and tagged as `vault_context`.
+- Reliability: learning loop and environment awareness are included in smoke output.
+- Execution: Ralph handoff is story-sized and gate-owned.
+- Release: `npm run release:verify` passes.
+
+## Leave-Behind
+
+- Send [Demo Story](./DEMO_STORY.md).
+- Send [Real Demo Runbook](./REAL_DEMO_RUNBOOK.md).
+- Send [DEMO.md](../../DEMO.md).
+- Confirm the next conversation date and the exact workspace or repository to evaluate.

--- a/docs/demo/REAL_DEMO_RUNBOOK.md
+++ b/docs/demo/REAL_DEMO_RUNBOOK.md
@@ -1,0 +1,105 @@
+# Real Demo Runbook
+
+This runbook demonstrates Meta-Architect with real package functions, seeded workspace data, Obsidian vault context, `$maestro` routing, learning-loop readiness, Ralph handoff, and release proof.
+
+Use it for live demos where the goal is to show MA handling an idea end-to-end instead of acting like a passive chatbot.
+
+## Demo Objective
+
+Show how a real workspace moves from a business idea to gated technical action:
+
+1. Install MA.
+2. Seed workspace context.
+3. Give `$maestro` a realistic release-hardening goal.
+4. Show MA selecting relevant lanes and preserving gate ownership.
+5. Show Obsidian notes as graph-linked `vault_context`.
+6. Show learning, context economy, environment awareness, Ralph handoff, and release verification.
+
+## Pain Point Map
+
+| Client objective | MA capability | Demo proof |
+| --- | --- | --- |
+| Stop late release surprises | `$maestro`, `$arch`, `$sage`, `$flow`, `$vet`, `$vibe`, `$build` | `.ma/plans/maestro.md`, `.ma/decisions.json`, `npm run release:verify` |
+| Use existing knowledge without polluting build evidence | Obsidian Integration Core | vault notes indexed as `vault_context`, graph-linked with wikilinks |
+| Make agent work reliable over time | Learning Loop, Environment Awareness, Context Economy, Ralph Execution Core | `npm run demo:smoke` JSON proof |
+
+## Live Path
+
+Install:
+
+```bash
+curl -fsSL https://cdn.jsdelivr.net/gh/JustineDevs/meta-architect@main/scripts/install.sh | sh
+```
+
+Fallback:
+
+```bash
+npm i -g @openai/codex@latest @jstn-sdk/ma@latest
+ma --madmax --high
+```
+
+Source checkout path:
+
+```bash
+git clone https://github.com/JustineDevs/meta-architect.git
+cd meta-architect
+npm install
+npm run demo:smoke
+```
+
+The smoke script creates a temporary Northstar Logistics workspace under `/tmp/ma-real-demo-*`, seeds a realistic Obsidian vault, runs MA runtime functions, and writes `.ma/evidence/real-demo-smoke-proof.json` inside that temporary workspace.
+
+## Realistic Live Prompt
+
+Use this inside Codex:
+
+```text
+$maestro Northstar Logistics wants to harden an existing dispatch analytics workspace for a production release. Inspect the repo, use Obsidian vault notes as brain context, choose the right MA roles, find risks, and produce the next release-safe action without asking for permission.
+```
+
+Expected behavior:
+
+- `$maestro` records manager state instead of asking whether to proceed.
+- `$arch` owns architecture direction.
+- `$sage` owns evidence boundaries.
+- `$flow` checks state and logic.
+- `$vet` catches security and compliance risk.
+- `$vibe` reviews DX/UX consequences.
+- `$build` remains gated until upstream lanes allow execution.
+
+## Obsidian Proof
+
+The smoke vault includes:
+
+- `Northstar/Dispatch Release Objective.md`
+- `Northstar/Risk Register.md`
+- `Meta-Architect/Core Brain Context.md`
+- `Meta-Architect/Release Gate Plan.md`
+- `Meta-Architect/Map of Content.md`
+
+Expected claims:
+
+- Notes record as `vault_context`.
+- Notes do not record as `build_evidence`.
+- MA notes use Obsidian wikilinks as semantic graph links.
+- Authoritative changes return through `$maestro` or the owning lane.
+
+## Backup Path
+
+If the live environment fails:
+
+```bash
+npm run demo:smoke
+npm run release:verify
+```
+
+Then show the generated JSON proof and the static runbook/story docs. This keeps the demo evidence real even when network, display, or Codex session conditions are unstable.
+
+## Leave-Behind
+
+Send these after the demo:
+
+- [Demo Story](./DEMO_STORY.md)
+- [Prospect Checklist](./PROSPECT_CHECKLIST.md)
+- [Repository Demo Guide](../../DEMO.md)
+- [Coverage Matrix](../../COVERAGE.md)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prepare": "husky",
     "postinstall": "node ./scripts/postinstall.js",
     "test": "node --test --test-concurrency=1",
+    "demo:smoke": "node ./scripts/demo-smoke.js",
     "status": "node ./bin/ma.js status",
     "linux:packages:build": "node ./scripts/build-linux-packages.mjs",
     "linux:packages:smoke": "node ./scripts/linux-package-smoke.mjs",

--- a/scripts/demo-smoke.js
+++ b/scripts/demo-smoke.js
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createContextEconomyView,
+  createDefaultLearningLoopCore,
+  createDefaultPromptStrategyCore,
+  createDiscoveredEnvironmentAwarenessCore,
+  createObsidianNote,
+  createRalphPrdContract,
+  evaluateLearningLoopReadiness,
+  indexObsidianVault,
+  readObsidianNote,
+  runIdea,
+  runInit,
+  updateObsidianNote,
+  validatePromptStrategyCore,
+  validateRalphPrdContract,
+  writeObsidianVaultIndex,
+} from "../index.js";
+import { loadRuntimeSnapshot } from "../src/runtime/runtime-state.js";
+import { runMaestro } from "../src/skills.js";
+
+const demoIdea =
+  "Northstar Logistics wants to harden an existing dispatch analytics workspace for a production release. MA must inspect current runtime context, use Obsidian vault notes as brain context, route through relevant roles, preserve security gates, and produce a release-safe next action instead of asking for permission.";
+
+async function writeFile(file, content) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, content, "utf8");
+}
+
+async function seedWorkspace(root) {
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "northstar-dispatch-analytics",
+        version: "2.4.0",
+        type: "module",
+        scripts: {
+          test: "node --test",
+          check: "node --check src/index.js",
+          release: "node scripts/release-check.js",
+        },
+        dependencies: {
+          "@modelcontextprotocol/sdk": "^1.0.0",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(
+    path.join(root, "src", "index.js"),
+    "export const serviceName = 'northstar-dispatch-analytics';\n",
+  );
+  await writeFile(
+    path.join(root, "mcp", "servers.json"),
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          "obsidian-api Docs": {
+            url: "https://gitmcp.io/obsidianmd/obsidian-api",
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+async function seedVault(vaultPath) {
+  await writeFile(
+    path.join(vaultPath, "Northstar", "Dispatch Release Objective.md"),
+    `---
+ma_records_as: vault_context
+ma_project: northstar-dispatch-analytics
+ma_capabilities:
+  - maestro
+  - obsidian
+  - learning-loop
+ma_source_workspace: northstar-dispatch-analytics
+---
+# Dispatch Release Objective
+
+Northstar Logistics needs a production-safe release plan for dispatch analytics.
+
+## Pain Points
+
+- Missed gate ownership causes late release rollback risk. #release
+- Unstructured knowledge lives in operations notes and is not visible to build planning. #knowledge
+- Security and DX review happen after implementation instead of before build execution. #security #dx
+
+## Links
+
+- [[Northstar/Risk Register]]
+- [[Meta-Architect/Core Brain Context]]
+`,
+  );
+  await writeFile(
+    path.join(vaultPath, "Northstar", "Risk Register.md"),
+    `---
+ma_records_as: vault_context
+ma_project: northstar-dispatch-analytics
+---
+# Risk Register
+
+Known risks:
+
+- Third-party carrier API failures can block dispatch reconciliation.
+- Customer PII must not be copied into prompt-bound release artifacts.
+- [[Northstar/Dispatch Release Objective]] owns the business target.
+`,
+  );
+  await writeFile(
+    path.join(vaultPath, "Meta-Architect", "Core Brain Context.md"),
+    `---
+ma_records_as: vault_context
+ma_project: northstar-dispatch-analytics
+---
+# Core Brain Context
+
+MA should treat this vault as semantic brain context only.
+Authoritative build evidence must return through $maestro or the owning lane.
+`,
+  );
+}
+
+function assertNoDemoBranding(value) {
+  const serialized = JSON.stringify(value);
+  assert.doesNotMatch(serialized, /Demo Account|Test Company|Sample Co|Acme/i);
+}
+
+async function main() {
+  const originalCwd = process.cwd();
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "ma-real-demo-"));
+  const vaultPath = path.join(workspace, "Northstar Vault");
+  await seedWorkspace(workspace);
+  await seedVault(vaultPath);
+
+  process.chdir(workspace);
+  try {
+    await runInit();
+    await runIdea(demoIdea);
+    await runMaestro();
+
+    const createdNote = await createObsidianNote({
+      vaultPath,
+      notePath: "Meta-Architect/Release Gate Plan.md",
+      overwrite: true,
+      content: `---
+ma_records_as: vault_context
+ma_project: northstar-dispatch-analytics
+ma_source_workspace: northstar-dispatch-analytics
+---
+# Release Gate Plan
+
+This note records the MA demo path for Northstar Logistics.
+
+- Start at [[Meta-Architect/Map of Content]]
+- Use [[Northstar/Dispatch Release Objective]] for buyer context
+- Keep build evidence in MA lane artifacts
+`,
+    });
+    await updateObsidianNote({
+      vaultPath,
+      notePath: "Meta-Architect/Release Gate Plan.md",
+      content: `${createdNote.relative_path ? "" : ""}---
+ma_records_as: vault_context
+ma_project: northstar-dispatch-analytics
+ma_source_workspace: northstar-dispatch-analytics
+---
+# Release Gate Plan
+
+This note records the MA demo path for Northstar Logistics.
+
+- Start at [[Meta-Architect/Map of Content]]
+- Use [[Northstar/Dispatch Release Objective]] for buyer context
+- Use [[Northstar/Risk Register]] for security and rollback concerns
+- Keep build evidence in MA lane artifacts
+`,
+    });
+    const readNote = await readObsidianNote({
+      vaultPath,
+      notePath: "Meta-Architect/Release Gate Plan.md",
+    });
+    const vaultIndex = await writeObsidianVaultIndex({ vaultPath });
+    const directVaultIndex = await indexObsidianVault({ vaultPath });
+
+    const learningReadiness = evaluateLearningLoopReadiness(createDefaultLearningLoopCore());
+    const promptStrategy = validatePromptStrategyCore(createDefaultPromptStrategyCore());
+    const contextEconomy = createContextEconomyView({
+      text: "The architecture lane should preserve exact commands, risk language, and verification gaps while compressing low-value filler for the live demo operator.",
+      level: "full",
+    });
+    const environmentAwareness = await createDiscoveredEnvironmentAwarenessCore({ cwd: workspace });
+    const ralphContract = validateRalphPrdContract(
+      createRalphPrdContract({
+        project: "northstar-dispatch-analytics",
+        branchName: "ralph/northstar-release-gates",
+        description: "Prepare release-safe dispatch analytics execution handoff.",
+        buildSlice: [
+          "Verify MA release gates before Ralph-style execution begins.",
+          "Preserve Obsidian context as vault_context, not build_evidence.",
+        ],
+        verificationPlan: [
+          "$arch, $sage, $flow, $vet, and $vibe are represented before $build.",
+          "Obsidian context is tagged as vault_context, not build_evidence.",
+        ],
+      }),
+    );
+    const runtimeSnapshot = await loadRuntimeSnapshot();
+
+    const proof = {
+      record_type: "ma_real_demo_smoke_proof",
+      workspace,
+      vaultPath,
+      idea: demoIdea,
+      maestro: {
+        global_status: runtimeSnapshot.maestroState.global_status,
+        track_count: Object.keys(runtimeSnapshot.maestroState.runtime_tracks).length,
+        next_plan_exists: true,
+      },
+      obsidian: {
+        note_count: vaultIndex.note_count,
+        records_as: vaultIndex.records_as,
+        build_evidence: vaultIndex.build_evidence,
+        graph_map_present: vaultIndex.notes.some(
+          (note) => note.relative_path === "Meta-Architect/Map of Content.md",
+        ),
+        linked_release_plan: readNote.content.includes("[[Meta-Architect/Map of Content]]"),
+        direct_index_note_count: directVaultIndex.note_count,
+      },
+      learning: {
+        domain_count: learningReadiness.domains,
+        verified_domain_count: learningReadiness.verified_domains,
+        ready: learningReadiness.ready,
+      },
+      prompt_strategy: {
+        lane_count: Object.keys(promptStrategy.lane_policy).length,
+      },
+      context_economy: {
+        mode: contextEconomy.mode,
+        preserved_exact_count: contextEconomy.preserved_exact.length,
+      },
+      environment_awareness: {
+        capability_count: environmentAwareness.capabilities.length,
+        capability_types: [
+          ...new Set(environmentAwareness.capabilities.map((item) => item.capability_type)),
+        ].sort(),
+      },
+      ralph: {
+        story_count: ralphContract.userStories.length,
+        authority: ralphContract.authority,
+      },
+    };
+
+    assert.equal(proof.obsidian.records_as, "vault_context");
+    assert.equal(proof.obsidian.build_evidence, false);
+    assert.equal(proof.obsidian.graph_map_present, true);
+    assert.equal(proof.obsidian.linked_release_plan, true);
+    assert.equal(proof.learning.ready, true);
+    assert.equal(proof.ralph.story_count, 1);
+    assertNoDemoBranding(proof);
+
+    await writeFile(
+      path.join(workspace, ".ma", "evidence", "real-demo-smoke-proof.json"),
+      `${JSON.stringify(proof, null, 2)}\n`,
+    );
+    console.log(JSON.stringify(proof, null, 2));
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/release-verify.js
+++ b/scripts/release-verify.js
@@ -168,6 +168,34 @@ function verifyReadmeReleaseBanner({ gitTag }) {
   }
 }
 
+function verifyRealDemoKit() {
+  const runbook = readText(path.join("docs", "demo", "REAL_DEMO_RUNBOOK.md"));
+  const story = readText(path.join("docs", "demo", "DEMO_STORY.md"));
+  const checklist = readText(path.join("docs", "demo", "PROSPECT_CHECKLIST.md"));
+  assert(fs.existsSync(path.join("scripts", "demo-smoke.js")), "scripts/demo-smoke.js: missing");
+  assert(
+    runbook.includes("npm run demo:smoke"),
+    "REAL_DEMO_RUNBOOK.md: missing demo smoke command",
+  );
+  assert(runbook.includes("$maestro"), "REAL_DEMO_RUNBOOK.md: missing maestro scenario");
+  assert(
+    runbook.includes("vault_context"),
+    "REAL_DEMO_RUNBOOK.md: missing Obsidian context boundary",
+  );
+  assert(story.includes("Northstar Logistics"), "DEMO_STORY.md: missing realistic buyer story");
+  assert(story.includes("npm run release:verify"), "DEMO_STORY.md: missing release proof close");
+  assert(
+    checklist.includes("Remove `Demo Account`, `Test Company`, `Sample Co`"),
+    "PROSPECT_CHECKLIST.md: missing no-test-branding check",
+  );
+  for (const forbidden of ["Demo Account", "Test Company", "Sample Co"]) {
+    assert(
+      !runbook.includes(forbidden) && !story.includes(forbidden),
+      `demo docs: forbidden visible demo branding ${forbidden}`,
+    );
+  }
+}
+
 function verifyCanonicalSemanticSurfaces({ version, gitTag }) {
   const usageWorkflow = readText(path.join("example", "usage-workflow.md"));
   assert(
@@ -257,6 +285,7 @@ function main() {
   verifyDemoDoc({ version, gitTag });
   verifyCoverageDoc({ version, gitTag });
   verifyReadmeReleaseBanner({ gitTag });
+  verifyRealDemoKit();
   verifyCanonicalSemanticSurfaces({ version, gitTag });
 
   const changelog = readText("CHANGELOG.md");


### PR DESCRIPTION
## Summary
- promotes the merged real demo kit from development to main
- includes npm run demo:smoke, docs/demo runbook/story/checklist, and release verification wiring

## Verification already passed on PR #33
- npm run demo:smoke
- npm run release:verify
- npm run check
- PR #33 validate, linux-packages, pr-check, codex-review, GitGuardian, and Snyk passed