### PR TITLE
Enhance README with detailed Meta-Architect overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,22 @@
   </p>
 </div>
 
-> [!NOTE]
-> Meta-Architect is a workflow layer for teams that want architecture, evidence, review, and release discipline before build execution.
-> Meta-Architect does not replace your coding runtime.
+## Overview  
+  
+**Meta-Architect (MA)** is a workflow layer for Codex-style CLIs and MCP-enabled coding agents — the layer that adds architecture, evidence, and release discipline *before* code gets built.  
+  
+**What Meta-Architect does:**  
+- Adds an architecture-first lane before implementation begins  
+- Backs technical decisions with evidence from GitMCP-connected OSS sources  
+- Enforces explicit logic, security, and DX/UX review gates before release  
+- Runs `$maestro`, a single bounded autonomous manager, alongside non-gating helper skills for alignment, diagnosis, test-first work, and cleanup  
+- Ships as installable skills with a reproducible, versioned package surface  
+  
+**What Meta-Architect does *not* do:**  
+Meta-Architect does not replace your coding runtime, your LLM, or your existing CLI agent. It wraps around whatever you already use — Codex or any MCP-enabled runtime — with architecture, evidence, gate enforcement, and release-sensitive workflow control layered on top.  
+  
+> [!NOTE]  
+> Meta-Architect does not replace your coding runtime.  
 > It wraps that runtime with architecture, evidence, gate enforcement, and release-sensitive workflow control.
 
 ## Navigate


### PR DESCRIPTION
Expanded the overview section to clarify the purpose and functionality of Meta-Architect, including what it does and does not do.

## Summary

Revises the ## Overview section of README.md (currently lines 25–39) to restructure the existing copy into an explicit "what it does" / "what it does not do" format, optimized for readability, SEO, AEO, and GEO — without introducing any new claimed capability. All facts (architecture-first lane, evidence-backed OSS selection via GitMCP, logic/security/DX-UX review gates, $maestro as the single bounded autonomous manager, non-gating helper skills, installable/reproducible skill packaging) are carried over unchanged from the current text README.md:25-39 .

## Base branch

- [ ] This PR targets `development`.
- [x] This PR targets `main` only as a curated promotion or maintainer exception.

If targeting `main`, explain why:

## Scope

- [ ] Skills
- [ ] Prompts
- [ ] MCP mappings
- [ ] Plugin surface
- [x] Docs
- [ ] CI / workflows
- [ ] Release packaging
- [ ] Other

## What changed

Restructured README.md's ## Overview section into a "What Meta-Architect does" / "What Meta-Architect does not do" layout for clearer scanning and quoting.
Kept the [!NOTE] boundary claim ("does not replace your coding runtime... wraps that runtime with architecture, evidence, gate enforcement, and release-sensitive workflow control") byte-for-byte unchanged, since generative/answer engines tend to preserve the clearest scope statement verbatim README.md:37-39 .
No new features, commands, or contracts were introduced — this is a wording/structure-only change to existing, already-shipped behavior.

## Why this change exists

The current Overview paragraph is dense prose that doesn't scan well for either humans skimming the repo or AI-driven search/answer surfaces summarizing "what is Meta-Architect." Restructuring into explicit positive/negative statement blocks makes the existing scope boundary (wraps, does not replace, your runtime) more directly extractable and consistent with the same language already used in the [!NOTE] callout README.md:37-39 and the plugin manifest's longDescription plugin.json:19 , reducing drift across the three descriptions of the project.
## Testing

List the checks you ran.

```bash
npm run skills:manifest
npm run skills:validate
npm run skills:pack
npm run skills:install -- --path ./dist/installed-skills
npm run check
npm test
```

Add any additional commands or manual verification notes below.

## Release sensitivity

- [ ] This PR changes release-sensitive files.
- [ ] This PR changes package metadata.
- [ ] This PR changes workflows.
- [ ] This PR changes skill contracts.
- [x] This PR does not affect release behavior.

If release-sensitive, explain the impact:

## Documentation

- [x] I updated relevant docs.
- [ ] No docs update was needed.

Docs touched:

- README.md (## Overview section)

## Runtime state hygiene

- [x] I did not commit runtime `.ma` files such as logs, state, tmp, or cache.
- [x] I verified no accidental release artifacts or temp files are included.

## Checklist

- [x] I performed a self-review.
- [x] The change is focused and intentional.
- [x] The behavior matches the documented contract.
- [x] I did not weaken gate enforcement or hide failures.
- [x] I included enough context for reviewers.
